### PR TITLE
Add support for Ubuntu 24 "Noble Numbat"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ in progress
 
 - Remove support for Debian 9 "stretch"
 - Added support for Debian 13 "trixie"
-
+- Added support for Ubuntu 24 "Noble Numbat"
 
 2023-02-14 0.3.0
 ================

--- a/postroj/registry.py
+++ b/postroj/registry.py
@@ -68,6 +68,13 @@ class CuratedOperatingSystem(Enum):
         version="22",
         image="https://cloud-images.ubuntu.com/minimal/daily/jammy/current/jammy-minimal-cloudimg-amd64-root.tar.xz",
     )
+    UBUNTU_NOBLE = LinuxDistribution(
+        family=OperatingSystemFamily.DEBIAN,
+        name=OperatingSystemName.UBUNTU,
+        release="noble",
+        version="24",
+        image="https://cloud-images.ubuntu.com/minimal/daily/noble/current/noble-minimal-cloudimg-amd64-root.tar.xz",
+    )
 
     # .rpm-based distributions
     FEDORA_35 = LinuxDistribution(
@@ -197,6 +204,7 @@ CURATED_OPERATING_SYSTEMS: List[Enum] = [
     CuratedOperatingSystem.DEBIAN_SID,
     CuratedOperatingSystem.UBUNTU_FOCAL,
     CuratedOperatingSystem.UBUNTU_JAMMY,
+    CuratedOperatingSystem.UBUNTU_NOBLE,
     # .rpm-based I
     CuratedOperatingSystem.FEDORA_35,
     CuratedOperatingSystem.FEDORA_36,

--- a/testing/postroj/test_images.py
+++ b/testing/postroj/test_images.py
@@ -39,6 +39,7 @@ def test_list_images():
         "debian-sid",
         "ubuntu-focal",
         "ubuntu-jammy",
+        "ubuntu-noble",
         "fedora-35",
         "fedora-36",
         "fedora-37",


### PR DESCRIPTION
Ubuntu 24.04.1 LTS was released on 29 August 2024.
https://ubuntu.com/blog/upgrade-your-desktop-ubuntu-24-04-lts